### PR TITLE
feat(act): add grantee module for managing grantees

### DIFF
--- a/src/bee.ts
+++ b/src/bee.ts
@@ -10,6 +10,7 @@ import { makeTopic, makeTopicFromString } from './feed/topic'
 import { DEFAULT_FEED_TYPE, FeedType, assertFeedType } from './feed/type'
 import * as bytes from './modules/bytes'
 import * as bzz from './modules/bzz'
+import * as grantee from './modules/grantee'
 import * as chunk from './modules/chunk'
 import * as balance from './modules/debug/balance'
 import * as chequebook from './modules/debug/chequebook'
@@ -314,7 +315,7 @@ export class Bee {
   ): Promise<GranteesResult> {
     assertBatchId(postageBatchId)
 
-    return bzz.createGrantees(this.getRequestOptionsForCall(requestOptions), postageBatchId, grantees)
+    return grantee.createGrantees(this.getRequestOptionsForCall(requestOptions), postageBatchId, grantees)
   }
 
   /**
@@ -328,7 +329,7 @@ export class Bee {
     reference: ReferenceOrEns | string,
     requestOptions?: BeeRequestOptions,
   ): Promise<GetGranteesResult> {
-    return bzz.getGrantees(reference, this.getRequestOptionsForCall(requestOptions))
+    return grantee.getGrantees(reference, this.getRequestOptionsForCall(requestOptions))
   }
 
   /**
@@ -350,7 +351,7 @@ export class Bee {
   ): Promise<GranteesResult> {
     assertBatchId(postageBatchId)
 
-    return bzz.patchGrantees(
+    return grantee.patchGrantees(
       reference,
       histrory,
       postageBatchId,

--- a/src/modules/bzz.ts
+++ b/src/modules/bzz.ts
@@ -8,8 +8,6 @@ import {
   DownloadRedundancyOptions,
   FileData,
   FileUploadOptions,
-  GetGranteesResult,
-  GranteesResult,
   Reference,
   ReferenceOrEns,
   UploadHeaders,
@@ -24,70 +22,6 @@ import { uploadTar } from '../utils/tar-uploader'
 import { isReadable, makeTagUid } from '../utils/type'
 
 const bzzEndpoint = 'bzz'
-const granteeEndpoint = 'grantee'
-
-export async function getGrantees(reference: string, requestOptions: BeeRequestOptions): Promise<GetGranteesResult> {
-  const response = await http<GetGranteesResult>(requestOptions, {
-    method: 'get',
-    url: `${granteeEndpoint}/${reference}`,
-    responseType: 'json',
-  })
-
-  return {
-    status: response.status,
-    statusText: response.statusText,
-    data: response.data.data,
-  }
-}
-
-export async function createGrantees(
-  requestOptions: BeeRequestOptions,
-  postageBatchId: BatchId,
-  grantees: string[],
-): Promise<GranteesResult> {
-  const response = await http<GranteesResult>(requestOptions, {
-    method: 'post',
-    url: granteeEndpoint,
-    data: { grantees: grantees },
-    headers: {
-      ...extractRedundantUploadHeaders(postageBatchId),
-    },
-    responseType: 'json',
-  })
-
-  return {
-    status: response.status,
-    statusText: response.statusText,
-    ref: response.data.ref,
-    historyref: response.data.historyref,
-  }
-}
-
-export async function patchGrantees(
-  reference: string,
-  historyRef: string,
-  postageBatchId: BatchId,
-  grantees: string,
-  requestOptions: BeeRequestOptions,
-): Promise<GranteesResult> {
-  const response = await http<GranteesResult>(requestOptions, {
-    method: 'patch',
-    url: `${granteeEndpoint}/${reference}`,
-    data: grantees,
-    headers: {
-      ...extractRedundantUploadHeaders(postageBatchId),
-      'swarm-act-history-address': historyRef,
-    },
-    responseType: 'json',
-  })
-
-  return {
-    status: response.status,
-    statusText: response.statusText,
-    ref: response.data.ref,
-    historyref: response.data.historyref,
-  }
-}
 
 interface FileUploadHeaders extends UploadHeaders {
   'content-length'?: string

--- a/src/modules/grantee.ts
+++ b/src/modules/grantee.ts
@@ -1,0 +1,68 @@
+import { BatchId, BeeRequestOptions, GetGranteesResult, GranteesResult } from '../types'
+import { extractRedundantUploadHeaders } from '../utils/headers'
+import { http } from '../utils/http'
+
+const granteeEndpoint = 'grantee'
+
+export async function getGrantees(reference: string, requestOptions: BeeRequestOptions): Promise<GetGranteesResult> {
+  const response = await http<GetGranteesResult>(requestOptions, {
+    method: 'get',
+    url: `${granteeEndpoint}/${reference}`,
+    responseType: 'json',
+  })
+
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    data: response.data.data,
+  }
+}
+
+export async function createGrantees(
+  requestOptions: BeeRequestOptions,
+  postageBatchId: BatchId,
+  grantees: string[],
+): Promise<GranteesResult> {
+  const response = await http<GranteesResult>(requestOptions, {
+    method: 'post',
+    url: granteeEndpoint,
+    data: { grantees: grantees },
+    headers: {
+      ...extractRedundantUploadHeaders(postageBatchId),
+    },
+    responseType: 'json',
+  })
+
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    ref: response.data.ref,
+    historyref: response.data.historyref,
+  }
+}
+
+export async function patchGrantees(
+  reference: string,
+  historyRef: string,
+  postageBatchId: BatchId,
+  grantees: string,
+  requestOptions: BeeRequestOptions,
+): Promise<GranteesResult> {
+  const response = await http<GranteesResult>(requestOptions, {
+    method: 'patch',
+    url: `${granteeEndpoint}/${reference}`,
+    data: grantees,
+    headers: {
+      ...extractRedundantUploadHeaders(postageBatchId),
+      'swarm-act-history-address': historyRef,
+    },
+    responseType: 'json',
+  })
+
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    ref: response.data.ref,
+    historyref: response.data.historyref,
+  }
+}

--- a/test/integration/modules/bzz.spec.ts
+++ b/test/integration/modules/bzz.spec.ts
@@ -1,4 +1,3 @@
-import { assert, expect } from 'chai'
 import { expect as jestExpect } from 'expect'
 import { Readable } from 'stream'
 import * as bzz from '../../../src/modules/bzz'
@@ -22,20 +21,6 @@ describe('modules/bzz', () => {
     const data = 'hello act'
     let publicKey: string
     let batchID: BatchId
-    const grantees = [
-      '02ceff1422a7026ba54ad89967d81f2805a55eb3d05f64eb5c49ea6024212b12e8',
-      '02ceff1422a7026ba54ad89967d81f2805a55eb3d05f64eb5c49ea6024212b12e9',
-      '02ceff1422a7026ba54ad89967d81f2805a55eb3d05f64eb5c49ea6024212b12ee',
-    ]
-    const patchGrantees = {
-      add: ['02ceff1422a7026ba54ad89967d81f2805a55eb3d05f64eb5c49ea6024212b12e8'],
-      revoke: [
-        '02ceff1422a7026ba54ad89967d81f2805a55eb3d05f64eb5c49ea6024212b12e9',
-        '02ceff1422a7026ba54ad89967d81f2805a55eb3d05f64eb5c49ea6024212b12ee',
-      ],
-    }
-
-    const patchGranteesString = JSON.stringify(patchGrantees)
 
     before(async () => {
       const responsePUBK = await http<{ publicKey: string }>(BEE_KY_OPTIONS, {
@@ -83,45 +68,6 @@ describe('modules/bzz', () => {
       const result = await bzz.uploadFile(BEE_KY_OPTIONS, data, batchID, filename, { act: true })
       const requestOptionsOK = actBeeKyOptions(publicKey, result.history_address, '1')
       const dFile = await bzz.downloadFile(requestOptionsOK, result.reference, filename)
-      expect(Buffer.from(dFile.data).toString()).to.eql(data)
-    })
-
-    it('should create grantee list', async function () {
-      const response = await bzz.createGrantees(BEE_KY_OPTIONS, batchID, grantees)
-      expect(response.ref).to.have.lengthOf(128)
-      expect(response.historyref).to.have.lengthOf(64)
-    })
-
-    it('should download grantee list', async function () {
-      const response = await bzz.createGrantees(BEE_KY_OPTIONS, batchID, grantees)
-      const list = await bzz.getGrantees(response.ref, BEE_KY_OPTIONS)
-      expect(list.data).to.have.lengthOf(grantees.length)
-      list.data.forEach((element: string, _index: number) => {
-        assert.isTrue(grantees.includes(element))
-      })
-    })
-
-    it('should patch grantee list', async function () {
-      const filename = 'act-4.txt'
-      const uploadResult = await bzz.uploadFile(BEE_KY_OPTIONS, data, batchID, filename, { act: true })
-
-      const createResponse = await bzz.createGrantees(BEE_KY_OPTIONS, batchID, grantees)
-      await new Promise(resolve => setTimeout(resolve, 1000))
-      const patchResponse = await bzz.patchGrantees(
-        createResponse.ref,
-        uploadResult.history_address,
-        batchID,
-        patchGranteesString,
-        BEE_KY_OPTIONS,
-      )
-      const list = await bzz.getGrantees(patchResponse.ref, BEE_KY_OPTIONS)
-
-      expect(list.data).to.have.lengthOf(1)
-      expect(list.data[0]).to.eql(patchGrantees.add[0])
-
-      const requestOptionsOK = actBeeKyOptions(publicKey, patchResponse.historyref, '1')
-      const dFile = await bzz.downloadFile(requestOptionsOK, uploadResult.reference, filename)
-
       expect(Buffer.from(dFile.data).toString()).to.eql(data)
     })
   })

--- a/test/integration/modules/grantee.spec.ts
+++ b/test/integration/modules/grantee.spec.ts
@@ -1,0 +1,82 @@
+import { BatchId } from '../../../src/types'
+import { http } from '../../../src/utils/http'
+import { actBeeKyOptions, beeKyOptions } from '../../utils'
+import * as bzz from '../../../src/modules/bzz'
+import * as grantee from '../../../src/modules/grantee'
+import { assert, expect } from 'chai'
+
+const BEE_KY_OPTIONS = beeKyOptions()
+
+describe('modules/grantee', () => {
+  let publicKey: string
+  let batchID: BatchId
+
+  before(async () => {
+    const responsePUBK = await http<{ publicKey: string }>(BEE_KY_OPTIONS, {
+      method: 'get',
+      url: 'addresses',
+      responseType: 'json',
+    })
+    publicKey = responsePUBK.data.publicKey
+
+    const responseBATCHID = await http<{ batchID: BatchId }>(BEE_KY_OPTIONS, {
+      method: 'post',
+      url: 'stamps/420000000/17',
+      responseType: 'json',
+    })
+    batchID = responseBATCHID.data.batchID
+  })
+  const grantees = [
+    '02ceff1422a7026ba54ad89967d81f2805a55eb3d05f64eb5c49ea6024212b12e8',
+    '02ceff1422a7026ba54ad89967d81f2805a55eb3d05f64eb5c49ea6024212b12e9',
+    '02ceff1422a7026ba54ad89967d81f2805a55eb3d05f64eb5c49ea6024212b12ee',
+  ]
+  const patchGrantees = {
+    add: ['02ceff1422a7026ba54ad89967d81f2805a55eb3d05f64eb5c49ea6024212b12e8'],
+    revoke: [
+      '02ceff1422a7026ba54ad89967d81f2805a55eb3d05f64eb5c49ea6024212b12e9',
+      '02ceff1422a7026ba54ad89967d81f2805a55eb3d05f64eb5c49ea6024212b12ee',
+    ],
+  }
+
+  const patchGranteesString = JSON.stringify(patchGrantees)
+  it('should create grantee list', async function () {
+    const response = await grantee.createGrantees(BEE_KY_OPTIONS, batchID, grantees)
+    expect(response.ref).to.have.lengthOf(128)
+    expect(response.historyref).to.have.lengthOf(64)
+  })
+
+  it('should download grantee list', async function () {
+    const response = await grantee.createGrantees(BEE_KY_OPTIONS, batchID, grantees)
+    const list = await grantee.getGrantees(response.ref, BEE_KY_OPTIONS)
+    expect(list.data).to.have.lengthOf(grantees.length)
+    list.data.forEach((element: string, _index: number) => {
+      assert.isTrue(grantees.includes(element))
+    })
+  })
+
+  it('should patch grantee list', async function () {
+    const filename = 'act-4.txt'
+    const data = 'hello act grantees!'
+    const uploadResult = await bzz.uploadFile(BEE_KY_OPTIONS, data, batchID, filename, { act: true })
+
+    const createResponse = await grantee.createGrantees(BEE_KY_OPTIONS, batchID, grantees)
+    await new Promise(resolve => setTimeout(resolve, 1000))
+    const patchResponse = await grantee.patchGrantees(
+      createResponse.ref,
+      uploadResult.history_address,
+      batchID,
+      patchGranteesString,
+      BEE_KY_OPTIONS,
+    )
+    const list = await grantee.getGrantees(patchResponse.ref, BEE_KY_OPTIONS)
+
+    expect(list.data).to.have.lengthOf(1)
+    expect(list.data[0]).to.eql(patchGrantees.add[0])
+
+    const requestOptionsOK = actBeeKyOptions(publicKey, patchResponse.historyref, '1')
+    const dFile = await bzz.downloadFile(requestOptionsOK, uploadResult.reference, filename)
+
+    expect(Buffer.from(dFile.data).toString()).to.eql(data)
+  })
+})


### PR DESCRIPTION
The code changes introduce a new module called `grantee` which handles the management of grantees. This module includes functions for getting grantees, creating grantees, and patching grantees. The existing code in the `bzz` module related to grantees has been moved to the new `grantee` module.